### PR TITLE
changed bc scale from 10 to 0 to get back integer

### DIFF
--- a/check_mailbox.sh
+++ b/check_mailbox.sh
@@ -118,7 +118,7 @@ else
 fi
 
 
-maxwait=$(bc <<< "scale = 10; ($critical+1500) / 1000")
+maxwait=$(bc <<< "scale = 0; ($critical+1500) / 1000")
 
 # Build the arg parameters
 insecurearg=""


### PR DESCRIPTION
curl is complaining

./check_mailbox.sh -H imaps://imap.googlemail.com -C "$IMAPCON" -S -n 0 -N 5
++ bc
+ maxwait=5.0000000000
+++ curl --url imaps://foo.bar -X 'EXAMINE INBOX' --user foo@bar:password -s --max-time 5.0000000000 --ssl --verbose
curl: option --max-time: expected a proper numerical parameter